### PR TITLE
Create SpotifyService

### DIFF
--- a/Clients/GlobalSpotifyClient.cs
+++ b/Clients/GlobalSpotifyClient.cs
@@ -1,0 +1,9 @@
+﻿using SpotifyAPI.Web;
+
+namespace homiefy_backend.Clients
+{
+    public class GlobalSpotifyClient
+    {
+        public static SpotifyClient Spotify;
+    }
+}

--- a/Constants.cs
+++ b/Constants.cs
@@ -15,3 +15,4 @@ namespace homiefy_backend
         public static List<string> HostUserScopes = new List<string> { Scopes.UserModifyPlaybackState };
     }
 }
+ 

--- a/Controllers/SpotifyController.cs
+++ b/Controllers/SpotifyController.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+using AutoMapper;
+
+using homiefy_backend.Domain.Models;
+using homiefy_backend.Services.Interfaces;
+using homiefy_backend.Resources;
+
+using Newtonsoft.Json;
+
+namespace homiefy_backend.Controllers
+{
+    [Route("api/v1/[controller]")]
+    [ApiController]
+    public class SpotifyController : Controller
+    {
+        private readonly ISpotifyService _spotifyService;
+        private readonly IMapper _mapper;
+
+        public SpotifyController(ISpotifyService spotifyService, IMapper mapper)        {
+            _spotifyService = spotifyService;
+            _mapper = mapper;
+        }
+
+        /*
+         * Checks if user is authorized
+         */
+        [HttpGet("is-user-authorized")]
+        public async Task<IActionResult> IsUserAuthorized()
+        {
+            var result = await _spotifyService.IsUserAuthorized();
+
+            if (!result.AuthenticationSuccess)
+            {
+                return StatusCode(500, $"{Values.UserIsNotAuthorized}\nException message: {result.ExceptionMessage}");
+            }
+
+            var authResult = _mapper.Map<AuthorizationResult, AuthorizationResultResource>(result);
+
+            return Ok(JsonConvert.SerializeObject(authResult));
+        }
+    }
+}

--- a/Mappers/ModelToResource/AuthorizationResultMapper.cs
+++ b/Mappers/ModelToResource/AuthorizationResultMapper.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+
+using homiefy_backend.Domain.Models;
+using homiefy_backend.Resources;
+
+namespace homiefy_backend.Mappers.ModelToResource
+{
+    public class AuthorizationResultMapper : Profile
+    {
+        public AuthorizationResultMapper()
+        {
+            CreateMap<AuthorizationResult, AuthorizationResultResource>();
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,9 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 });
 
 builder.Services.AddScoped<IAuthenticationCredentialRepository, AuthenticationCredentialRepository>();
+
 builder.Services.AddScoped<IAuthorizationService, AuthorizationService>();
+builder.Services.AddScoped<ISpotifyService, SpotifyService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/Resources/AuthorizationResultResource.cs
+++ b/Resources/AuthorizationResultResource.cs
@@ -1,6 +1,6 @@
-﻿namespace homiefy_backend.Domain.Models
+﻿namespace homiefy_backend.Resources
 {
-    public class AuthorizationResult
+    public class AuthorizationResultResource
     {
         public bool AuthenticationSuccess;
 

--- a/Services/AuthorizationService.cs
+++ b/Services/AuthorizationService.cs
@@ -1,4 +1,5 @@
-﻿using homiefy_backend.Services.Interfaces;
+﻿using homiefy_backend.Clients;
+using homiefy_backend.Services.Interfaces;
 using homiefy_backend.Domain.Models;
 using homiefy_backend.Persistence.Repositories.Interfaces;
 
@@ -45,6 +46,9 @@ namespace homiefy_backend.Services
             return new AuthorizationUrlResponse { AuthorizationUrl = request.ToUri().ToString() };
         }
 
+        /*
+         * 
+
         // ========================================================================================================================================================================================================
 
         /*
@@ -60,7 +64,8 @@ namespace homiefy_backend.Services
 
             var config = SpotifyClientConfig.CreateDefault().WithToken(token.AccessToken, token.TokenType);
             //var config = SpotifyClientConfig.CreateDefault().WithAuthenticator(new AuthorizationCodeAuthenticator(_hostClientId, _hostClientSecret, token));
-            _spotifyHostUser = new SpotifyClient(config);
+            //_spotifyHostUser = new SpotifyClient(config);
+            GlobalSpotifyClient.Spotify = new SpotifyClient(config); // @todo do this better
         }
 
         private async Task OnErrorRecieved(object sender, string error, string state)

--- a/Services/Interfaces/ISpotifyService.cs
+++ b/Services/Interfaces/ISpotifyService.cs
@@ -1,0 +1,9 @@
+﻿using homiefy_backend.Domain.Models;
+
+namespace homiefy_backend.Services.Interfaces
+{
+    public interface ISpotifyService
+    {
+        Task<AuthorizationResult> IsUserAuthorized();
+    }
+}

--- a/Services/SpotifyService.cs
+++ b/Services/SpotifyService.cs
@@ -1,0 +1,59 @@
+﻿using homiefy_backend.Clients;
+using homiefy_backend.Domain.Models;
+using homiefy_backend.Services.Interfaces;
+
+using SpotifyAPI.Web;
+
+namespace homiefy_backend.Services
+{
+    /*
+     * This service interacts with the Spotify API.
+     * I plan to write some higher level services like a QueueService or something, that lets users manipulate a queue before it gets sent to Spotify.
+     */
+    public class SpotifyService : ISpotifyService
+    {
+        private SpotifyClient _spotify;
+
+
+        public SpotifyService()
+        {
+            _spotify = GlobalSpotifyClient.Spotify;
+        }
+
+        /*
+         * Tests to make sure user is authorized
+         */
+        public async Task<AuthorizationResult> IsUserAuthorized()
+        { 
+            try
+            {
+                var user = await _spotify.UserProfile.Current();
+                return new AuthorizationResult()
+                {
+                    AuthenticationSuccess = true,
+                    SpotifyDisplayName = user.DisplayName,
+                    SpotifyId = user.Id
+                };
+            }
+            catch (Exception e)
+            {
+                return new AuthorizationResult()
+                {
+                    AuthenticationSuccess = false,
+                    ExceptionMessage = e.Message
+                };
+            }
+        }
+
+        /*
+         * Add a song to the queue
+         */
+
+        /*
+         * Remove a song from the queue
+         */
+
+
+
+    }
+}

--- a/Values.cs
+++ b/Values.cs
@@ -1,7 +1,14 @@
 ﻿namespace homiefy_backend
 {
+    /*
+     * Poor man's resources.rex
+     */
+
+    // @TODO implement a good resources system
+
     public class Values
     {
         public static String FailedToGetAuthorizationUrl = "Failed to get Authorization URL from Spotify API.";
+        public static String UserIsNotAuthorized = "User is not authorized to use this application with Spotify API.";
     }
 }

--- a/homiefy-backend.csproj
+++ b/homiefy-backend.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SpotifyAPI.Web" Version="6.2.2" />
     <PackageReference Include="SpotifyAPI.Web.Auth" Version="6.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />


### PR DESCRIPTION
- Create SpotifyClient: a global class with a static SpotifyAPI.Web.SpotifyClient object for transferring a SpotifyClient instance from the AuthorizationService to the SpotifyService
- Created a SpotifyController which will be the basis for all Spotify-related endpoints
- Changes to models & mappers
- Create a SpotifyService class. This class will handle all the interaction with the Spotify API. Currently now it has a method for verifying the user is authorized. When called before building an authorization url and hitting it, it will return ise500. If an authorization url is built from the endpoint, navigated to and authorized in the (hypothetical) frontend, then this endpoint is called, it will return an object with the username and user id of the authorized user.