### PR TITLE
Add a basic implementation of a queue and search endpoint to SpotifyService

### DIFF
--- a/Controllers/SpotifyController.cs
+++ b/Controllers/SpotifyController.cs
@@ -17,7 +17,8 @@ namespace homiefy_backend.Controllers
         private readonly ISpotifyService _spotifyService;
         private readonly IMapper _mapper;
 
-        public SpotifyController(ISpotifyService spotifyService, IMapper mapper)        {
+        public SpotifyController(ISpotifyService spotifyService, IMapper mapper)
+        {
             _spotifyService = spotifyService;
             _mapper = mapper;
         }
@@ -38,6 +39,28 @@ namespace homiefy_backend.Controllers
             var authResult = _mapper.Map<AuthorizationResult, AuthorizationResultResource>(result);
 
             return Ok(JsonConvert.SerializeObject(authResult));
+        }
+
+        /*
+         * Adds a song to the queue
+         */
+        [HttpPost("add-to-queue")]
+        public async Task<IActionResult> AddToQueue(string uri)
+        {
+            var result = await _spotifyService.AddToQueue(uri);
+
+            if (!result) return StatusCode(500, $"{Values.FailedToAddToQueue}\nURI: {uri}");
+            else return Ok("Add song to queue.");
+        }
+
+        /*
+         * Searches a track using spotify api and returns results.
+         */
+        [HttpGet("search-track")]
+        public async Task<IActionResult> SearchTrack(string query)
+        {
+            var result = await _spotifyService.Search(query);
+            return Ok(JsonConvert.SerializeObject(result));
         }
     }
 }

--- a/Services/Interfaces/ISpotifyService.cs
+++ b/Services/Interfaces/ISpotifyService.cs
@@ -1,9 +1,13 @@
 ﻿using homiefy_backend.Domain.Models;
 
+using SpotifyAPI.Web;
+
 namespace homiefy_backend.Services.Interfaces
 {
     public interface ISpotifyService
     {
         Task<AuthorizationResult> IsUserAuthorized();
+        Task<bool> AddToQueue(string songUri);
+        Task<SearchResponse> Search(string searchTerm);
     }
 }

--- a/Services/SpotifyService.cs
+++ b/Services/SpotifyService.cs
@@ -48,11 +48,23 @@ namespace homiefy_backend.Services
         /*
          * Add a song to the queue
          */
+        public async Task<bool> AddToQueue(string songUri)
+        {
+            return await _spotify.Player.AddToQueue(new PlayerAddToQueueRequest(songUri));
+        }
 
         /*
-         * Remove a song from the queue
+         * Search a query and return the results
          */
-
+        public async Task<SearchResponse> Search(string searchTerm)
+        {
+            // @TODO validate searchTerm
+            // @TODO support searching songs, artists, etc
+            SearchRequest req = new SearchRequest(query: searchTerm, type: SearchRequest.Types.Track);
+            SearchResponse resp = await _spotify.Search.Item(req);
+            return resp;
+        }
+        
 
 
     }

--- a/Values.cs
+++ b/Values.cs
@@ -10,5 +10,6 @@
     {
         public static String FailedToGetAuthorizationUrl = "Failed to get Authorization URL from Spotify API.";
         public static String UserIsNotAuthorized = "User is not authorized to use this application with Spotify API.";
+        public static string FailedToAddToQueue = "Failed to add song to queue";
     }
 }


### PR DESCRIPTION
- Add a basic implementation of a search and add to queue endpoint
- still needs some polishing - model serialization/mapping, support for more params when searching (track, artist, etc), error handling, etc